### PR TITLE
Cache comment checker tree-sitter queries

### DIFF
--- a/pkg/core/detector.go
+++ b/pkg/core/detector.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	sitter "github.com/smacker/go-tree-sitter"
 
@@ -11,12 +12,17 @@ import (
 )
 
 type CommentDetector struct {
-	registry *LanguageRegistry
+	registry         *LanguageRegistry
+	queryMu          sync.Mutex
+	commentQueries   map[string]*sitter.Query
+	docstringQueries map[string]*sitter.Query
 }
 
 func NewCommentDetector() *CommentDetector {
 	return &CommentDetector{
-		registry: NewLanguageRegistry(),
+		registry:         NewLanguageRegistry(),
+		commentQueries:   make(map[string]*sitter.Query),
+		docstringQueries: make(map[string]*sitter.Query),
 	}
 }
 
@@ -46,16 +52,10 @@ func (d *CommentDetector) Detect(content, filePath string, includeDocstrings boo
 	}
 	defer tree.Close()
 
-	queryPattern := QueryTemplates[langName]
-	if queryPattern == "" {
-		queryPattern = "(comment) @comment"
-	}
-
-	query, err := sitter.NewQuery([]byte(queryPattern), lang)
-	if err != nil {
+	query := d.commentQueryFor(langName, lang)
+	if query == nil {
 		return nil
 	}
-	defer query.Close()
 
 	qc := sitter.NewQueryCursor()
 	defer qc.Close()
@@ -98,16 +98,10 @@ func (d *CommentDetector) Detect(content, filePath string, includeDocstrings boo
 }
 
 func (d *CommentDetector) detectDocstrings(sourceCode []byte, filePath string, lang *sitter.Language, langName string, tree *sitter.Tree) []models.CommentInfo {
-	docQuery, ok := DocstringQueries[langName]
-	if !ok {
+	query := d.docstringQueryFor(langName, lang)
+	if query == nil {
 		return nil
 	}
-
-	query, err := sitter.NewQuery([]byte(docQuery), lang)
-	if err != nil {
-		return nil
-	}
-	defer query.Close()
 
 	qc := sitter.NewQueryCursor()
 	defer qc.Close()
@@ -135,6 +129,47 @@ func (d *CommentDetector) detectDocstrings(sourceCode []byte, filePath string, l
 	}
 
 	return docstrings
+}
+
+func (d *CommentDetector) commentQueryFor(langName string, lang *sitter.Language) *sitter.Query {
+	queryPattern := QueryTemplates[langName]
+	if queryPattern == "" {
+		queryPattern = "(comment) @comment"
+	}
+
+	return d.cachedQuery(d.commentQueries, langName, queryPattern, lang)
+}
+
+func (d *CommentDetector) docstringQueryFor(langName string, lang *sitter.Language) *sitter.Query {
+	docQuery, ok := DocstringQueries[langName]
+	if !ok {
+		return nil
+	}
+
+	return d.cachedQuery(d.docstringQueries, langName, docQuery, lang)
+}
+
+func (d *CommentDetector) cachedQuery(
+	cache map[string]*sitter.Query,
+	langName string,
+	queryPattern string,
+	lang *sitter.Language,
+) *sitter.Query {
+	d.queryMu.Lock()
+	defer d.queryMu.Unlock()
+
+	query := cache[langName]
+	if query != nil {
+		return query
+	}
+
+	compiledQuery, err := sitter.NewQuery([]byte(queryPattern), lang)
+	if err != nil {
+		return nil
+	}
+
+	cache[langName] = compiledQuery
+	return compiledQuery
 }
 
 func (d *CommentDetector) determineCommentType(text, nodeType string) models.CommentType {

--- a/pkg/core/detector_test.go
+++ b/pkg/core/detector_test.go
@@ -3,8 +3,8 @@ package core
 import (
 	"testing"
 
-	"github.com/stretchr/testify/assert"
 	"github.com/code-yeongyu/go-claude-code-comment-checker/pkg/models"
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_Detect_PythonLineComment_ReturnsCommentInfo(t *testing.T) {
@@ -97,4 +97,26 @@ func main() {}`
 	assert.Equal(t, "main.go", comments[0].FilePath)
 	assert.Equal(t, models.CommentTypeLine, comments[0].CommentType)
 	assert.False(t, comments[0].IsDocstring)
+}
+
+func Test_Detect_RepeatedPythonChecks_ReusesCompiledQueries(t *testing.T) {
+	// given
+	detector := NewCommentDetector()
+	code := `"""Module docstring."""
+# regular comment
+def hello():
+    """Function docstring."""
+    return "world"`
+
+	// when
+	for range 20 {
+		comments := detector.Detect(code, "module.py", true)
+		assert.Len(t, comments, 3)
+	}
+
+	// then
+	detector.queryMu.Lock()
+	defer detector.queryMu.Unlock()
+	assert.Len(t, detector.commentQueries, 1)
+	assert.Len(t, detector.docstringQueries, 1)
 }


### PR DESCRIPTION
## Summary
- Cache tree-sitter queries per detector/language to avoid repeated query compilation.
- Add tests for cache reuse behavior.

## Improvement table
| Benchmark | Initial baseline | Final benchmark | Delta |
| --- | ---: | ---: | ---: |
| `BenchmarkCommentDetectorDetectPythonNoDocstrings-18` | `714618 ns/op`, `1056 B/op`, `22 allocs/op` | `11275 ns/op`, `1024 B/op`, `19 allocs/op` | ~63.4x faster, -32 B/op, -3 allocs/op |
| `BenchmarkCommentDetectorDetectPythonWithDocstrings-18` | `3617623 ns/op`, `2096 B/op`, `43 allocs/op` | `14156 ns/op`, `1800 B/op`, `34 allocs/op` | ~255.6x faster, -296 B/op, -9 allocs/op |
| Unsupported extension | `12.71 ns/op`, `0 B/op`, `0 allocs/op` | unchanged fast path | Zero-allocation unsupported-file path preserved |

## Verification
- go build -o comment-checker ./cmd/comment-checker
- go test ./...
- go test -race ./pkg/core
- go test -bench='BenchmarkCommentDetectorDetectPython(NoDocstrings|WithDocstrings)$' -benchmem ./pkg/core
- manual CLI pass/warning QA

## Review
- Security, QA, context, and goal-verifier lanes completed locally.
- Cubic review passed before merge.
